### PR TITLE
Update metro transformer import for RN 0.56

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ const reactNativeVersionString = require('react-native/package.json').version;
 
 const reactNativeMinorVersion = semver(reactNativeVersionString).minor;
 
-if (reactNativeMinorVersion >= 52) {
+if (reactNativeMinorVersion >= 56) {
+  upstreamTransformer = require('metro/src/reactNativeTransformer')
+} else if (reactNativeMinorVersion >= 52) {
   upstreamTransformer = require('metro/src/transformer');
 } else if (reactNativeMinorVersion >= 0.47) {
   upstreamTransformer = require('metro-bundler/src/transformer');


### PR DESCRIPTION
Example taken form react-native-typescript-transformer : 
![image](https://user-images.githubusercontent.com/9041221/47004368-b2502680-d131-11e8-9329-9ee31b1dde3d.png)
