### PR TITLE
update README to include instructions for React Native 0.57+

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ query PostListItemQuery($id: ID) {
 
 ### Step 1: Install
 
-    yarn add -D react-native-graphql-transformer
+    yarn add -D @bam.tech/react-native-graphql-transformer
 
 ### Step 2: Configure the react native packager
 
@@ -48,7 +48,9 @@ module.exports = (async () => {
   } = await getDefaultConfig();
   return {
     transformer: {
-      babelTransformerPath: require.resolve('react-native-graphql-transformer'),
+      babelTransformerPath: require.resolve(
+        '@bam.tech/react-native-graphql-transformer'
+      ),
     },
     resolver: {
       sourceExts: [...sourceExts, 'gql', 'graphql'],
@@ -62,7 +64,7 @@ module.exports = (async () => {
 ```js
 module.exports = {
   getTransformModulePath() {
-    return require.resolve('react-native-graphql-transformer');
+    return require.resolve('@bam.tech/react-native-graphql-transformer');
   },
   getSourceExts() {
     return ['gql', 'graphql'];

--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ query PostListItemQuery($id: ID) {
 
 Add this to your rn-cli.config.js (make one if you don't have one already):
 
+#### react-native 0.57 or later
+
+```js
+const { getDefaultConfig } = require('metro-config');
+
+module.exports = (async () => {
+  const {
+    resolver: { sourceExts },
+  } = await getDefaultConfig();
+  return {
+    transformer: {
+      babelTransformerPath: require.resolve('react-native-graphql-transformer'),
+    },
+    resolver: {
+      sourceExts: [...sourceExts, 'gql', 'graphql'],
+    },
+  };
+})();
+```
+
+#### react-native 0.56 or earlier
+
 ```js
 module.exports = {
   getTransformModulePath() {


### PR DESCRIPTION
Thanks for your excellent work on this plugin.

Metro bundler changed its configuration format, starting with the version bundled with react native 0.57. This PR updates the `README` to include a configuration snippet which is compatible with this new syntax (largely cribbed from [`react-native-sass-transformer`](https://github.com/kristerkari/react-native-sass-transformer).)