### PR TITLE
if metro >= 0.51, require from metro-react-native-babel-transformer

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,14 @@ let upstreamTransformer = null;
 
 const reactNativeVersionString = require('react-native/package.json').version;
 
+const metroVersion = parseFloat(require('metro/package.json').version);
+
 const reactNativeMinorVersion = semver(reactNativeVersionString).minor;
 
-if (reactNativeMinorVersion >= 56) {
-  upstreamTransformer = require('metro/src/reactNativeTransformer')
+if (metroVersion >= 0.51) {
+  upstreamTransformer = require('metro-react-native-babel-transformer/src/index');
+} else if (reactNativeMinorVersion >= 56) {
+  upstreamTransformer = require('metro/src/reactNativeTransformer');
 } else if (reactNativeMinorVersion >= 52) {
   upstreamTransformer = require('metro/src/transformer');
 } else if (reactNativeMinorVersion >= 0.47) {


### PR DESCRIPTION
This solves: https://github.com/bamlab/react-native-graphql-transformer/issues/6